### PR TITLE
Allow instantiating Mrkt client with existing access_token and expiry

### DIFF
--- a/lib/mrkt.rb
+++ b/lib/mrkt.rb
@@ -34,6 +34,8 @@ module Mrkt
 
       @client_id = options.fetch(:client_id)
       @client_secret = options.fetch(:client_secret)
+      @token = options.fetch(:access_token, nil)
+      @valid_until = options.fetch(:expires_at, nil)
       @partner_id = options.fetch(:partner_id, nil)
 
       @retry_authentication = options.fetch(:retry_authentication, false)


### PR DESCRIPTION
Pass an existing Marketo access token and its UTC expiry date in order to prevent making a request to Marketo's authentication endpoint when we already have a valid API token.